### PR TITLE
Compare attribute codes using lowercase

### DIFF
--- a/src/AttributeOptionMapper.php
+++ b/src/AttributeOptionMapper.php
@@ -30,7 +30,7 @@ final class AttributeOptionMapper extends DataMapper
     private function obtainOptionCodeFromPrefixedOptionCode(Akeneo3AttributeOption $attributeOption)
     {
         $optionCodes = explode('-', $attributeOption->getOptionCode());
-        return count($optionCodes) >= 2 && $optionCodes[0] === $attributeOption->getAttributeCode() ?
+        return count($optionCodes) >= 2 && strtolower($optionCodes[0]) === strtolower($attributeOption->getAttributeCode()) ?
             implode('-', array_slice($optionCodes, 1)) :
             $attributeOption->getOptionCode();
     }


### PR DESCRIPTION
Attribute option codes are prefixed with the attribute code to prevent clashes. This bit of code will attempt to remove it before saving it to magento.
We've recently introduced support for uppercase attributes, which are just lowercased (See: https://github.com/snowio/akeneo3-data-model/pull/4) so we add that check here as well.