### PR TITLE
Failback missing family label

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ before_install:
   - composer self-update
   - composer config repositories.packagist.com composer https://repo.packagist.com/snowio/
   - if [[ -n $PACKAGIST_TOKEN ]]; then composer config http-basic.repo.packagist.com token $PACKAGIST_TOKEN; fi
+  - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 cache:
   directories: $HOME/.composer/cache
 before_script: composer install --no-interaction --dev

--- a/src/FamilyMapper.php
+++ b/src/FamilyMapper.php
@@ -61,6 +61,8 @@ final class FamilyMapper extends DataMapper
         $attributeSetName = $familyData->getLabel($this->defaultLocale);
         if ($attributeSetName === 'Default') {
             $attributeSetName = 'PIM Default';
+        } elseif (null === $attributeSetName) {
+            $attributeSetName = $familyData->getCode();
         }
         return AttributeSetData::of(EntityTypeCode::PRODUCT, $familyData->getCode(), $attributeSetName)
             ->withAttributeGroups(AttributeGroupDataSet::of(\iterator_to_array($magentoAttributeGroups)));

--- a/src/FamilyMapper.php
+++ b/src/FamilyMapper.php
@@ -58,11 +58,9 @@ final class FamilyMapper extends DataMapper
             Kv::of('attributes', $attributesPerGroup),
         ]);
 
-        $attributeSetName = $familyData->getLabel($this->defaultLocale);
+        $attributeSetName = $familyData->getLabel($this->defaultLocale) ?? $familyData->getCode();
         if ($attributeSetName === 'Default') {
             $attributeSetName = 'PIM Default';
-        } elseif (null === $attributeSetName) {
-            $attributeSetName = $familyData->getCode();
         }
         return AttributeSetData::of(EntityTypeCode::PRODUCT, $familyData->getCode(), $attributeSetName)
             ->withAttributeGroups(AttributeGroupDataSet::of(\iterator_to_array($magentoAttributeGroups)));

--- a/test/unit/EventMapper/FamilyMessageMapperTest.php
+++ b/test/unit/EventMapper/FamilyMessageMapperTest.php
@@ -47,6 +47,15 @@ class FamilyMessageMapperTest extends TestCase
                 'new' => ['@timestamp' => 1234] + $this->getFamilyJson()
             ],
         ];
+
+        yield [
+            FamilyMapper::withDefaultLocale('en_GB')->getTransform(),
+            [
+                'old' => null,
+                'new' => ['@timestamp' => 1234] + $this->getFamilyJson(null)
+            ],
+            SaveAttributeSetCommand::of($this->getAttributeSetData())->withTimestamp(1234),
+        ];
     }
 
     private function getFamilyJson(): array
@@ -115,9 +124,9 @@ class FamilyMessageMapperTest extends TestCase
         ];
     }
 
-    private function getAttributeSetData(): AttributeSetData
+    private function getAttributeSetData(?string $name = 'Trousers'): AttributeSetData
     {
-        return AttributeSetData::of(EntityTypeCode::PRODUCT, 'trousers', 'Trousers')
+        return AttributeSetData::of(EntityTypeCode::PRODUCT, 'trousers', $name)
             ->withAttributeGroup(
                 AttributeGroupData::of('default', 'Default (Akeneo)')
                     ->withSortOrder(0)


### PR DESCRIPTION
Adds a failback to null values when the export is triggered on families still not yet translated. 